### PR TITLE
Modal enhancements

### DIFF
--- a/sdk/packages/modal/src/components/nightly-footer/nightly-footer.css
+++ b/sdk/packages/modal/src/components/nightly-footer/nightly-footer.css
@@ -1,0 +1,53 @@
+.nc_footerBackground {
+  position: relative;
+  top: -60px;
+  width: 100%;
+  height: 30px;
+  background-color: var(--nc-color-elements-3);
+  z-index: -1;
+}
+
+.nc_footerContent {
+  position: relative;
+  width: 100%;
+  height: 40px;
+  border-radius: 0px 0px 16px 16px;
+  background-color: var(--nc-color-elements-3);
+  display: flex;
+  align-items: center;
+  padding: 16px;
+}
+
+.nc_footerText {
+  color: var(--nc-color-elements-6);
+  font-size: var(--nc-font-size-3);
+}
+
+.nc_footerText > a {
+  color: var(--nc-color-primary);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+@media (max-width: 960px) {
+  .nc_footerText {
+    font-size: var(--nc-font-size-2);
+  }
+
+  .nc_footerContent {
+    padding: 12px 16px 12px 16px;
+  }
+}
+
+@media (max-width: 640px) {
+  .nc_footerBackground {
+    height: 0px;
+    top: 0px;
+  }
+
+  .nc_footerContent {
+    padding: 10px 16px 10px 16px;
+    border-radius: 0px;
+    top: -20px;
+  }
+}

--- a/sdk/packages/modal/src/components/nightly-footer/nightly-footer.stories.ts
+++ b/sdk/packages/modal/src/components/nightly-footer/nightly-footer.stories.ts
@@ -1,0 +1,25 @@
+import { Meta, StoryObj } from '@storybook/web-components'
+import { html } from 'lit/static-html.js'
+import './nightly-footer'
+import { NightlyFooter } from './nightly-footer'
+
+const meta = {
+  title: 'nightly-footer',
+  parameters: {
+    layout: 'centered'
+  },
+  render: (args) => {
+    return html`<nightly-footer .termsOfServiceLink=${args.termsOfServiceLink} .privacyPolicyLink=${args.privacyPolicyLink}/>`
+  }
+} satisfies Meta<NightlyFooter>
+
+export default meta
+type Story = StoryObj<NightlyFooter>
+
+export const Default: Story = {
+  name: 'Default',
+  args: {
+    termsOfServiceLink: "",
+    privacyPolicyLink: "",
+  }
+}

--- a/sdk/packages/modal/src/components/nightly-footer/nightly-footer.stories.ts
+++ b/sdk/packages/modal/src/components/nightly-footer/nightly-footer.stories.ts
@@ -9,7 +9,7 @@ const meta = {
     layout: 'centered'
   },
   render: (args) => {
-    return html`<nightly-footer .termsOfServiceLink=${args.termsOfServiceLink} .privacyPolicyLink=${args.privacyPolicyLink}/>`
+    return html`<nightly-footer .footerTextData=${args.footerTextData} />`
   }
 } satisfies Meta<NightlyFooter>
 
@@ -19,7 +19,6 @@ type Story = StoryObj<NightlyFooter>
 export const Default: Story = {
   name: 'Default',
   args: {
-    termsOfServiceLink: "",
-    privacyPolicyLink: "",
+    footerTextData: ["By connecting, you agree to Common's ", { url: "", name: "Terms of Service" }, " and its ", { url: "", name: "Privacy Policy" }, "."],
   }
 }

--- a/sdk/packages/modal/src/components/nightly-footer/nightly-footer.ts
+++ b/sdk/packages/modal/src/components/nightly-footer/nightly-footer.ts
@@ -2,22 +2,29 @@ import { customElement, property } from 'lit/decorators.js'
 import { tailwindElement } from '../../shared/tailwind.element'
 import style from './nightly-footer.css'
 import { LitElement, html } from 'lit'
+import { FooterTextData } from '../../utils/types'
+
 
 @customElement('nightly-footer')
 export class NightlyFooter extends LitElement {
   static styles = tailwindElement(style)
 
-  @property()
-  termsOfServiceLink: string = ""
+  @property({ type: Array })
+  footerTextData: ReadonlyArray<FooterTextData> | undefined= [];
 
-  @property()
-  privacyPolicyLink: string = ""
+  parseTextData = (item: FooterTextData) => {
+    if (typeof item === 'string') {
+      return html`${item}`;
+    } else {
+      return html`<a href=${item.url}>${item.name}</a>`;
+    }    
+  }
 
   render() {
     return html`
       <div class="nc_footerContent">
         <div class="nc_footerText">
-          By connecting, you agree to Common's <a href=${this.termsOfServiceLink}>Terms of Service</a> and its <a href=${this.privacyPolicyLink}>Privacy Policy</a>.
+          ${this.footerTextData && this.footerTextData.map(this.parseTextData)}
         </div>
       </div>
       <div class="nc_footerBackground" />

--- a/sdk/packages/modal/src/components/nightly-footer/nightly-footer.ts
+++ b/sdk/packages/modal/src/components/nightly-footer/nightly-footer.ts
@@ -1,0 +1,32 @@
+import { customElement, property } from 'lit/decorators.js'
+import { tailwindElement } from '../../shared/tailwind.element'
+import style from './nightly-footer.css'
+import { LitElement, html } from 'lit'
+
+@customElement('nightly-footer')
+export class NightlyFooter extends LitElement {
+  static styles = tailwindElement(style)
+
+  @property()
+  termsOfServiceLink: string = ""
+
+  @property()
+  privacyPolicyLink: string = ""
+
+  render() {
+    return html`
+      <div class="nc_footerContent">
+        <div class="nc_footerText">
+          By connecting, you agree to Common's <a href=${this.termsOfServiceLink}>Terms of Service</a> and its <a href=${this.privacyPolicyLink}>Privacy Policy</a>.
+        </div>
+      </div>
+      <div class="nc_footerBackground" />
+    `
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'nightly-footer': NightlyFooter
+  }
+}

--- a/sdk/packages/modal/src/components/nightly-selector/nightly-selector.css
+++ b/sdk/packages/modal/src/components/nightly-selector/nightly-selector.css
@@ -1,20 +1,22 @@
+/* duration | easing-function | delay | iteration-count | direction | fill-mode | play-state | name */
+
 .nc_modalOverlay {
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  animation: 100ms ease-out 0s 1 fadeIn normal forwards;
+  animation: 300ms linear 0s 1 normal forwards fadeIn;
   z-index: 100;
   background-color: var(--nc-color-overlay);
-  backdrop-filter: blur(10px);
 }
 
 .nc_modalWrapper {
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translateX(-50%) translateY(-50%);
+  opacity: 0;
+  animation: 50ms linear 250ms 1 normal forwards slideIn;
   width: 720px;
   display: flex;
   flex-direction: column;
@@ -29,12 +31,16 @@
   transition: height 250ms;
 }
 
-.nc_modalClosingAnimation {
-  animation: 100ms ease-out 0s 1 fadeOut normal forwards;
-}
-
 .nc_modalViewEntryTransition {
   animation: 300ms ease-out 0s 1 viewsFadeIn normal forwards;
+}
+
+.nc_modalOverlayClosingAnimation {
+  animation: 300ms linear 0ms 1 normal forwards fadeOut;
+}
+
+.nc_modalSlideOutAnimation {
+  animation: 300ms ease-out 0s 1 normal forwards slideOut;
 }
 
 @media (max-width: 1080px) {
@@ -51,7 +57,7 @@
 
 @media (max-width: 640px) {
   .nc_modalOverlay {
-    animation: 250ms ease-out 0s 1 fadeInMobile normal forwards;
+    animation: 250ms ease-out 0s 1 normal forwards fadeIn;
     background-color: transparent;
     backdrop-filter: blur(0);
   }
@@ -62,7 +68,8 @@
     bottom: -20px;
     width: 100%;
     transform-origin: 0 100%;
-    animation: 250ms ease-out 0s 1 slideIn normal forwards;
+    animation: 250ms ease-out 0s 1 normal forwards slideInMobile;
+    opacity: 1;
   }
 
   .nc_modalContent {
@@ -72,33 +79,33 @@
   }
 
   .nc_modalClosingAnimation {
-    animation: 250ms ease-out 0s 1 fadeOutMobile normal forwards;
+    animation: 300ms ease-out 0s 1 normal forwards fadeOut;
   }
 
-  .nc_modalMobileSlideOutAnimation {
-    animation: 250ms ease-out 0s 1 slideOut normal forwards;
+  .nc_modalSlideOutAnimation {
+    animation: 250ms ease-out 0s 1 normal forwards slideOutMobile;
+  }
+
+  @keyframes slideInMobile {
+    0% {
+      transform: translateY(100%);
+    }
+    100% {
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes slideOutMobile {
+    0% {
+      transform: translateY(0);
+    }
+    100% {
+      transform: translateY(100%);
+    }
   }
 }
 
 @keyframes fadeIn {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-@keyframes fadeOut {
-  0% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
-}
-
-@keyframes fadeInMobile {
   0% {
     background-color: transparent;
     backdrop-filter: blur(0);
@@ -109,7 +116,7 @@
   }
 }
 
-@keyframes fadeOutMobile {
+@keyframes fadeOut {
   0% {
     background-color: var(--nc-color-overlay);
     backdrop-filter: blur(10px);
@@ -122,21 +129,26 @@
 
 @keyframes slideIn {
   0% {
-    transform: translateY(100%);
-  }
-  100% {
-    transform: translateY(0);
-  }
-}
+    opacity: 0;
+    transform: translateX(-50%) translateY(-60%);
+  } 
+  100% { 
+    opacity: 1;
+    transform: translateX(-50%) translateY(-50%);
+  } 
+} 
 
 @keyframes slideOut {
   0% {
-    transform: translateY(0);
-  }
-  100% {
-    transform: translateY(100%);
-  }
-}
+    opacity: 1;
+    transform: translateX(-50%) translateY(-50%);
+  } 
+  100% { 
+    opacity: 0;
+    transform: translateX(-50%) translateY(-40%);
+  } 
+} 
+
 
 @keyframes viewsFadeIn {
   0% {

--- a/sdk/packages/modal/src/components/nightly-selector/nightly-selector.css
+++ b/sdk/packages/modal/src/components/nightly-selector/nightly-selector.css
@@ -1,5 +1,3 @@
-/* duration | easing-function | delay | iteration-count | direction | fill-mode | play-state | name */
-
 .nc_modalOverlay {
   position: fixed;
   top: 0;

--- a/sdk/packages/modal/src/components/nightly-selector/nightly-selector.stories.ts
+++ b/sdk/packages/modal/src/components/nightly-selector/nightly-selector.stories.ts
@@ -13,7 +13,7 @@ import Binance from '../../static/svg/BinanceIcon.svg'
 import Sollet from '../../static/svg/SolletIcon.svg'
 import NightlyIcon from '../../static/svg/NightlyIcon.svg'
 import ChainIcon from '../../static/svg/ChainIcon.svg'
-import { WalletSelectorItem } from '../../utils/types'
+import { FooterTextData, WalletSelectorItem } from '../../utils/types'
 
 const meta = {
   title: 'nightly-selector',
@@ -38,6 +38,7 @@ interface NightlyModalArgs {
   sessionId: string
   connecting: boolean
   relay: string
+  footerTextData: ReadonlyArray<FooterTextData> | undefined
 }
 type Story = StoryObj<NightlyModalArgs & { open: boolean }>
 
@@ -60,6 +61,7 @@ export const Default: Story = (args: NightlyModalArgs) => {
           .sessionId=${args.sessionId}
           ?connecting=${args.connecting}
           .relay=${args.relay}
+          .footerTextData=${args.footerTextData}
         ></nightly-selector>
       `
     : html``
@@ -114,5 +116,6 @@ Default.args = {
     'fsdhfdzfsdhgfzghggdfhbgchgbdfnvfbxhncvfjhzxdhgbhghfgfvzhfgjhgszdhgzxdfhgfzxdjfuhdfhgd',
   connecting: true,
   relay: 'https://nc2.nightly.app',
-  open: true
+  open: true,
+  footerTextData: ["By connecting, you agree to Common's ", { url: "", name: "Terms of Service" }, " and its ", { url: "", name: "Privacy Policy" }, "."],
 }

--- a/sdk/packages/modal/src/components/nightly-selector/nightly-selector.stories.ts
+++ b/sdk/packages/modal/src/components/nightly-selector/nightly-selector.stories.ts
@@ -13,7 +13,7 @@ import Binance from '../../static/svg/BinanceIcon.svg'
 import Sollet from '../../static/svg/SolletIcon.svg'
 import NightlyIcon from '../../static/svg/NightlyIcon.svg'
 import ChainIcon from '../../static/svg/ChainIcon.svg'
-import { FooterTextData, WalletSelectorItem } from '../../utils/types'
+import { AdditionalModalConfig, WalletSelectorItem } from '../../utils/types'
 
 const meta = {
   title: 'nightly-selector',
@@ -38,7 +38,7 @@ interface NightlyModalArgs {
   sessionId: string
   connecting: boolean
   relay: string
-  footerTextData: ReadonlyArray<FooterTextData> | undefined
+  additionalModalConfig: AdditionalModalConfig | undefined;
 }
 type Story = StoryObj<NightlyModalArgs & { open: boolean }>
 
@@ -61,7 +61,7 @@ export const Default: Story = (args: NightlyModalArgs) => {
           .sessionId=${args.sessionId}
           ?connecting=${args.connecting}
           .relay=${args.relay}
-          .footerTextData=${args.footerTextData}
+          .additionalModalConfig=${args.additionalModalConfig}
         ></nightly-selector>
       `
     : html``
@@ -117,5 +117,7 @@ Default.args = {
   connecting: true,
   relay: 'https://nc2.nightly.app',
   open: true,
-  footerTextData: ["By connecting, you agree to Common's ", { url: "", name: "Terms of Service" }, " and its ", { url: "", name: "Privacy Policy" }, "."],
+  additionalModalConfig: {
+    footerTextData: ["By connecting, you agree to Common's ", { url: "", name: "Terms of Service" }, " and its ", { url: "", name: "Privacy Policy" }, "."],
+  }
 }

--- a/sdk/packages/modal/src/components/nightly-selector/nightly-selector.ts
+++ b/sdk/packages/modal/src/components/nightly-selector/nightly-selector.ts
@@ -2,7 +2,7 @@ import { LitElement, html } from 'lit'
 import { customElement, property, state } from 'lit/decorators.js'
 import { tailwindElement } from '../../shared/tailwind.element'
 import style from './nightly-selector.css'
-import { SelectorView, WalletSelectorItem } from '../../utils/types'
+import { SelectorView, WalletSelectorItem, FooterTextData } from '../../utils/types'
 import { styleMap } from 'lit/directives/style-map.js'
 import '../nightly-desktop-main/nightly-desktop-main'
 import '../nightly-connect-wallet/nightly-connect-wallet'
@@ -47,6 +47,9 @@ export class NightlySelector extends LitElement {
 
   @property({ type: Object })
   qrConfigOverride: Partial<XMLOptions> = {}
+
+  @property({ type: Array })
+  footerTextData: ReadonlyArray<FooterTextData> | undefined = []
 
   // state
 
@@ -321,7 +324,7 @@ export class NightlySelector extends LitElement {
           >
             ${this.renderCurrent()}
           </div>
-          <nightly-footer .termsOfServiceLink="" .privacyPolicyLink=""/>
+          <nightly-footer .footerTextData=${this.footerTextData} />
         </div>
       </div>
     `

--- a/sdk/packages/modal/src/components/nightly-selector/nightly-selector.ts
+++ b/sdk/packages/modal/src/components/nightly-selector/nightly-selector.ts
@@ -2,7 +2,7 @@ import { LitElement, html } from 'lit'
 import { customElement, property, state } from 'lit/decorators.js'
 import { tailwindElement } from '../../shared/tailwind.element'
 import style from './nightly-selector.css'
-import { SelectorView, WalletSelectorItem, FooterTextData } from '../../utils/types'
+import { SelectorView, WalletSelectorItem, AdditionalModalConfig } from '../../utils/types'
 import { styleMap } from 'lit/directives/style-map.js'
 import '../nightly-desktop-main/nightly-desktop-main'
 import '../nightly-connect-wallet/nightly-connect-wallet'
@@ -48,8 +48,8 @@ export class NightlySelector extends LitElement {
   @property({ type: Object })
   qrConfigOverride: Partial<XMLOptions> = {}
 
-  @property({ type: Array })
-  footerTextData: ReadonlyArray<FooterTextData> | undefined = []
+  @property({ type: Object })
+  additionalModalConfig: AdditionalModalConfig | undefined
 
   // state
 
@@ -324,7 +324,7 @@ export class NightlySelector extends LitElement {
           >
             ${this.renderCurrent()}
           </div>
-          <nightly-footer .footerTextData=${this.footerTextData} />
+          <nightly-footer .footerTextData=${this.additionalModalConfig?.footerTextData} />
         </div>
       </div>
     `

--- a/sdk/packages/modal/src/components/nightly-selector/nightly-selector.ts
+++ b/sdk/packages/modal/src/components/nightly-selector/nightly-selector.ts
@@ -106,7 +106,7 @@ export class NightlySelector extends LitElement {
       () => {
         this.onClose()
       },
-      this.mobileQuery.matches ? 240 : 80
+      300
     )
   }
 
@@ -297,7 +297,7 @@ export class NightlySelector extends LitElement {
   render() {
     return html`
       <div
-        class="nc_modalOverlay ${this.fireClosingAnimation ? 'nc_modalClosingAnimation' : ''}"
+        class="nc_modalOverlay ${this.fireClosingAnimation ? 'nc_modalOverlayClosingAnimation' : ''}"
         @click=${this.handleClose}
       >
         <div
@@ -305,7 +305,7 @@ export class NightlySelector extends LitElement {
             e.stopPropagation()
           }}
           class="nc_modalWrapper ${this.fireClosingAnimation
-            ? 'nc_modalMobileSlideOutAnimation'
+            ? 'nc_modalSlideOutAnimation'
             : ''}"
         >
           <nightly-header .onClose=${this.handleClose}></nightly-header>

--- a/sdk/packages/modal/src/components/nightly-selector/nightly-selector.ts
+++ b/sdk/packages/modal/src/components/nightly-selector/nightly-selector.ts
@@ -7,6 +7,7 @@ import { styleMap } from 'lit/directives/style-map.js'
 import '../nightly-desktop-main/nightly-desktop-main'
 import '../nightly-connect-wallet/nightly-connect-wallet'
 import '../nightly-header/nightly-header'
+import '../nightly-footer/nightly-footer'
 import '../nightly-mobile-all-wallets/nightly-mobile-all-wallets'
 import '../nightly-mobile-qr/nightly-mobile-qr'
 import '../nightly-mobile-main/nightly-mobile-main'
@@ -320,6 +321,7 @@ export class NightlySelector extends LitElement {
           >
             ${this.renderCurrent()}
           </div>
+          <nightly-footer .termsOfServiceLink="" .privacyPolicyLink=""/>
         </div>
       </div>
     `

--- a/sdk/packages/modal/src/utils/types.ts
+++ b/sdk/packages/modal/src/utils/types.ts
@@ -19,3 +19,12 @@ export enum SelectorView {
   MOBILE_ALL,
   CONNECTING
 }
+
+type FooterText = string;
+
+interface FooterLink {
+  url: string;
+  name: string;
+}
+
+export type FooterTextData = FooterText | FooterLink;

--- a/sdk/packages/modal/src/utils/types.ts
+++ b/sdk/packages/modal/src/utils/types.ts
@@ -28,3 +28,7 @@ interface FooterLink {
 }
 
 export type FooterTextData = FooterText | FooterLink;
+
+export interface AdditionalModalConfig {
+  footerTextData: ReadonlyArray<FooterTextData> | undefined
+}

--- a/sdk/packages/selector-base/src/modal.ts
+++ b/sdk/packages/selector-base/src/modal.ts
@@ -1,5 +1,5 @@
 import { type XMLOptions, type NightlySelector } from '@nightlylabs/wallet-selector-modal'
-import { type IWalletListItem, type NetworkData, type FooterTextData } from './types'
+import { type IWalletListItem, type NetworkData, type AdditionalModalConfig } from './types'
 import { isMobileBrowser } from './utils'
 
 export class NightlyConnectSelectorModal {
@@ -9,7 +9,7 @@ export class NightlyConnectSelectorModal {
   _networkData: NetworkData
   _relay: string
   _walletsList: IWalletListItem[] = []
-  _footerTextData?: FooterTextData[]
+  _additionalModalConfig?: AdditionalModalConfig
 
   _open = false
 
@@ -24,13 +24,13 @@ export class NightlyConnectSelectorModal {
     variablesOverride?: object,
     stylesOverride?: string,
     qrConfigOverride?: Partial<XMLOptions>,
-    footerTextData?: FooterTextData[]
+    additionalModalConfig?: AdditionalModalConfig
   ) {
     this.walletsList = walletsList
     this._relay = relay
     this._networkData = networkData
     this._anchor = anchorRef ?? document.body
-    this._footerTextData = footerTextData
+    this._additionalModalConfig = additionalModalConfig
     this.createSelectorElement(variablesOverride, stylesOverride, qrConfigOverride)
   }
 
@@ -61,7 +61,7 @@ export class NightlyConnectSelectorModal {
       this._modal.chainIcon = this._networkData.icon
       this._modal.chainName = this._networkData.name
       this._modal.selectorItems = this.walletsList
-      this._modal.footerTextData = this._footerTextData
+      this._modal.additionalModalConfig = this._additionalModalConfig
     })
   }
 

--- a/sdk/packages/selector-base/src/modal.ts
+++ b/sdk/packages/selector-base/src/modal.ts
@@ -1,5 +1,5 @@
 import { type XMLOptions, type NightlySelector } from '@nightlylabs/wallet-selector-modal'
-import { type IWalletListItem, type NetworkData } from './types'
+import { type IWalletListItem, type NetworkData, type FooterTextData } from './types'
 import { isMobileBrowser } from './utils'
 
 export class NightlyConnectSelectorModal {
@@ -9,6 +9,7 @@ export class NightlyConnectSelectorModal {
   _networkData: NetworkData
   _relay: string
   _walletsList: IWalletListItem[] = []
+  _footerTextData?: FooterTextData[]
 
   _open = false
 
@@ -22,12 +23,14 @@ export class NightlyConnectSelectorModal {
     anchorRef?: HTMLElement | null,
     variablesOverride?: object,
     stylesOverride?: string,
-    qrConfigOverride?: Partial<XMLOptions>
+    qrConfigOverride?: Partial<XMLOptions>,
+    footerTextData?: FooterTextData[]
   ) {
     this.walletsList = walletsList
     this._relay = relay
     this._networkData = networkData
     this._anchor = anchorRef ?? document.body
+    this._footerTextData = footerTextData
     this.createSelectorElement(variablesOverride, stylesOverride, qrConfigOverride)
   }
 
@@ -58,6 +61,7 @@ export class NightlyConnectSelectorModal {
       this._modal.chainIcon = this._networkData.icon
       this._modal.chainName = this._networkData.name
       this._modal.selectorItems = this.walletsList
+      this._modal.footerTextData = this._footerTextData
     })
   }
 

--- a/sdk/packages/selector-base/src/types.ts
+++ b/sdk/packages/selector-base/src/types.ts
@@ -32,3 +32,12 @@ export enum ConnectionType {
   Nightly = 'Nightly',
   WalletStandard = 'WalletStandard'
 }
+
+type FooterText = string;
+
+interface FooterLink {
+  url: string;
+  name: string;
+}
+
+export type FooterTextData = FooterText | FooterLink;

--- a/sdk/packages/selector-base/src/types.ts
+++ b/sdk/packages/selector-base/src/types.ts
@@ -41,3 +41,7 @@ interface FooterLink {
 }
 
 export type FooterTextData = FooterText | FooterLink;
+
+export interface AdditionalModalConfig {
+  footerTextData: ReadonlyArray<FooterTextData> | undefined
+}

--- a/sdk/packages/selector-polkadot/src/adapter.ts
+++ b/sdk/packages/selector-polkadot/src/adapter.ts
@@ -17,7 +17,8 @@ import {
   persistStandardConnectForNetwork,
   persistStandardDisconnectForNetwork,
   sleep,
-  triggerConnect
+  triggerConnect,
+  FooterTextData
 } from '@nightlylabs/wallet-selector-base'
 
 import { type Signer as InjectedSigner } from '@polkadot/api/types'
@@ -147,7 +148,8 @@ export class NightlyConnectAdapter implements Injected {
       variablesOverride?: object
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
-    }
+    },
+    footerTextData?: FooterTextData[]
   ) => {
     if (!useEagerConnect) {
       clearSessionIdForNetwork(appInitData.network)
@@ -166,7 +168,8 @@ export class NightlyConnectAdapter implements Injected {
       anchorRef,
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
-      uiOverrides?.qrConfigOverride
+      uiOverrides?.qrConfigOverride,
+      footerTextData,
     )
 
     const [app, metadataWallets] = await NightlyConnectAdapter.initApp(appInitData)
@@ -190,7 +193,8 @@ export class NightlyConnectAdapter implements Injected {
       variablesOverride?: object
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
-    }
+    },
+    footerTextData?: FooterTextData[]
   ) => {
     if (!useEagerConnect) {
       clearSessionIdForNetwork(appInitData.network)
@@ -209,7 +213,8 @@ export class NightlyConnectAdapter implements Injected {
       anchorRef,
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
-      uiOverrides?.qrConfigOverride
+      uiOverrides?.qrConfigOverride,
+      footerTextData
     )
 
     adapter._loading = true
@@ -240,7 +245,8 @@ export class NightlyConnectAdapter implements Injected {
       variablesOverride?: object
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
-    }
+    },
+    footerTextData?: FooterTextData[]
   ) => {
     if (!useEagerConnect) {
       clearSessionIdForNetwork(appInitData.network)
@@ -259,7 +265,8 @@ export class NightlyConnectAdapter implements Injected {
       anchorRef,
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
-      uiOverrides?.qrConfigOverride
+      uiOverrides?.qrConfigOverride,
+      footerTextData
     )
 
     return adapter

--- a/sdk/packages/selector-polkadot/src/adapter.ts
+++ b/sdk/packages/selector-polkadot/src/adapter.ts
@@ -18,7 +18,7 @@ import {
   persistStandardDisconnectForNetwork,
   sleep,
   triggerConnect,
-  FooterTextData
+  AdditionalModalConfig
 } from '@nightlylabs/wallet-selector-base'
 
 import { type Signer as InjectedSigner } from '@polkadot/api/types'
@@ -149,7 +149,7 @@ export class NightlyConnectAdapter implements Injected {
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
     },
-    footerTextData?: FooterTextData[]
+    additionalModalConfig?: AdditionalModalConfig
   ) => {
     if (!useEagerConnect) {
       clearSessionIdForNetwork(appInitData.network)
@@ -169,7 +169,7 @@ export class NightlyConnectAdapter implements Injected {
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
       uiOverrides?.qrConfigOverride,
-      footerTextData,
+      additionalModalConfig,
     )
 
     const [app, metadataWallets] = await NightlyConnectAdapter.initApp(appInitData)
@@ -194,7 +194,7 @@ export class NightlyConnectAdapter implements Injected {
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
     },
-    footerTextData?: FooterTextData[]
+    additionalModalConfig?: AdditionalModalConfig
   ) => {
     if (!useEagerConnect) {
       clearSessionIdForNetwork(appInitData.network)
@@ -214,7 +214,7 @@ export class NightlyConnectAdapter implements Injected {
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
       uiOverrides?.qrConfigOverride,
-      footerTextData
+      additionalModalConfig
     )
 
     adapter._loading = true
@@ -246,7 +246,7 @@ export class NightlyConnectAdapter implements Injected {
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
     },
-    footerTextData?: FooterTextData[]
+    additionalModalConfig?: AdditionalModalConfig
   ) => {
     if (!useEagerConnect) {
       clearSessionIdForNetwork(appInitData.network)
@@ -266,7 +266,7 @@ export class NightlyConnectAdapter implements Injected {
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
       uiOverrides?.qrConfigOverride,
-      footerTextData
+      additionalModalConfig
     )
 
     return adapter

--- a/sdk/packages/selector-solana/src/adapter.ts
+++ b/sdk/packages/selector-solana/src/adapter.ts
@@ -17,7 +17,7 @@ import {
   persistStandardDisconnectForNetwork,
   sleep,
   XMLOptions,
-  FooterTextData
+  AdditionalModalConfig
 } from '@nightlylabs/wallet-selector-base'
 import {
   BaseMessageSignerWalletAdapter,
@@ -162,7 +162,7 @@ export class NightlyConnectAdapter extends BaseMessageSignerWalletAdapter {
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
     },
-    footerTextData?: FooterTextData[]
+    additionalModalConfig?: AdditionalModalConfig
   ) => {
     const adapter = new NightlyConnectAdapter(appInitData, eagerConnectForStandardWallets)
 
@@ -187,7 +187,7 @@ export class NightlyConnectAdapter extends BaseMessageSignerWalletAdapter {
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
       uiOverrides?.qrConfigOverride,
-      footerTextData
+      additionalModalConfig
     )
 
     const [app, metadataWallets] = await NightlyConnectAdapter.initApp(appInitData)
@@ -213,7 +213,7 @@ export class NightlyConnectAdapter extends BaseMessageSignerWalletAdapter {
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
     },
-    footerTextData?: FooterTextData[]
+    additionalModalConfig?: AdditionalModalConfig
   ) => {
     const adapter = new NightlyConnectAdapter(appInitData, eagerConnectForStandardWallets)
 
@@ -238,7 +238,7 @@ export class NightlyConnectAdapter extends BaseMessageSignerWalletAdapter {
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
       uiOverrides?.qrConfigOverride,
-      footerTextData
+      additionalModalConfig
     )
 
     adapter._loading = true
@@ -268,7 +268,7 @@ export class NightlyConnectAdapter extends BaseMessageSignerWalletAdapter {
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
     },
-    footerTextData?: FooterTextData[]
+    additionalModalConfig?: AdditionalModalConfig
   ) => {
     const adapter = new NightlyConnectAdapter(appInitData, eagerConnectForStandardWallets, true)
 
@@ -293,7 +293,7 @@ export class NightlyConnectAdapter extends BaseMessageSignerWalletAdapter {
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
       uiOverrides?.qrConfigOverride,
-      footerTextData
+      additionalModalConfig
     )
 
     return adapter

--- a/sdk/packages/selector-solana/src/adapter.ts
+++ b/sdk/packages/selector-solana/src/adapter.ts
@@ -16,7 +16,8 @@ import {
   triggerConnect,
   persistStandardDisconnectForNetwork,
   sleep,
-  XMLOptions
+  XMLOptions,
+  FooterTextData
 } from '@nightlylabs/wallet-selector-base'
 import {
   BaseMessageSignerWalletAdapter,
@@ -160,7 +161,8 @@ export class NightlyConnectAdapter extends BaseMessageSignerWalletAdapter {
       variablesOverride?: object
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
-    }
+    },
+    footerTextData?: FooterTextData[]
   ) => {
     const adapter = new NightlyConnectAdapter(appInitData, eagerConnectForStandardWallets)
 
@@ -184,7 +186,8 @@ export class NightlyConnectAdapter extends BaseMessageSignerWalletAdapter {
       anchorRef,
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
-      uiOverrides?.qrConfigOverride
+      uiOverrides?.qrConfigOverride,
+      footerTextData
     )
 
     const [app, metadataWallets] = await NightlyConnectAdapter.initApp(appInitData)
@@ -209,7 +212,8 @@ export class NightlyConnectAdapter extends BaseMessageSignerWalletAdapter {
       variablesOverride?: object
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
-    }
+    },
+    footerTextData?: FooterTextData[]
   ) => {
     const adapter = new NightlyConnectAdapter(appInitData, eagerConnectForStandardWallets)
 
@@ -233,7 +237,8 @@ export class NightlyConnectAdapter extends BaseMessageSignerWalletAdapter {
       anchorRef,
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
-      uiOverrides?.qrConfigOverride
+      uiOverrides?.qrConfigOverride,
+      footerTextData
     )
 
     adapter._loading = true
@@ -262,7 +267,8 @@ export class NightlyConnectAdapter extends BaseMessageSignerWalletAdapter {
       variablesOverride?: object
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
-    }
+    },
+    footerTextData?: FooterTextData[]
   ) => {
     const adapter = new NightlyConnectAdapter(appInitData, eagerConnectForStandardWallets, true)
 
@@ -286,7 +292,8 @@ export class NightlyConnectAdapter extends BaseMessageSignerWalletAdapter {
       anchorRef,
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
-      uiOverrides?.qrConfigOverride
+      uiOverrides?.qrConfigOverride,
+      footerTextData
     )
 
     return adapter

--- a/sdk/packages/selector-sui/src/adapter.ts
+++ b/sdk/packages/selector-sui/src/adapter.ts
@@ -29,7 +29,7 @@ import {
   persistStandardDisconnectForNetwork,
   sleep,
   triggerConnect,
-  FooterTextData
+  AdditionalModalConfig
 } from '@nightlylabs/wallet-selector-base'
 import type { StandardEventsOnMethod, WalletAccount } from '@wallet-standard/core'
 import bs58 from 'bs58'
@@ -144,7 +144,7 @@ export class NightlyConnectSuiAdapter {
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
     },
-    footerTextData?: FooterTextData[]
+    additionalModalConfig?: AdditionalModalConfig
   ) => {
     const adapter = new NightlyConnectSuiAdapter(appInitData, eagerConnectForStandardWallets)
 
@@ -164,7 +164,7 @@ export class NightlyConnectSuiAdapter {
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
       uiOverrides?.qrConfigOverride,
-      footerTextData
+      additionalModalConfig
     )
 
     const [app, metadataWallets] = await NightlyConnectSuiAdapter.initApp(appInitData)
@@ -189,7 +189,7 @@ export class NightlyConnectSuiAdapter {
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
     },
-    footerTextData?: FooterTextData[]
+    additionalModalConfig?: AdditionalModalConfig
   ) => {
     const adapter = new NightlyConnectSuiAdapter(appInitData, eagerConnectForStandardWallets)
 
@@ -209,7 +209,7 @@ export class NightlyConnectSuiAdapter {
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
       uiOverrides?.qrConfigOverride,
-      footerTextData
+      additionalModalConfig
     )
 
     adapter._loading = true
@@ -236,7 +236,7 @@ export class NightlyConnectSuiAdapter {
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
     },
-    footerTextData?: FooterTextData[]
+    additionalModalConfig?: AdditionalModalConfig
   ) => {
     const adapter = new NightlyConnectSuiAdapter(appInitData, eagerConnectForStandardWallets, true)
 
@@ -257,7 +257,7 @@ export class NightlyConnectSuiAdapter {
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
       uiOverrides?.qrConfigOverride,
-      footerTextData
+      additionalModalConfig
     )
 
     return adapter

--- a/sdk/packages/selector-sui/src/adapter.ts
+++ b/sdk/packages/selector-sui/src/adapter.ts
@@ -28,7 +28,8 @@ import {
   persistStandardConnectForNetwork,
   persistStandardDisconnectForNetwork,
   sleep,
-  triggerConnect
+  triggerConnect,
+  FooterTextData
 } from '@nightlylabs/wallet-selector-base'
 import type { StandardEventsOnMethod, WalletAccount } from '@wallet-standard/core'
 import bs58 from 'bs58'
@@ -142,7 +143,8 @@ export class NightlyConnectSuiAdapter {
       variablesOverride?: object
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
-    }
+    },
+    footerTextData?: FooterTextData[]
   ) => {
     const adapter = new NightlyConnectSuiAdapter(appInitData, eagerConnectForStandardWallets)
 
@@ -161,7 +163,8 @@ export class NightlyConnectSuiAdapter {
       anchorRef,
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
-      uiOverrides?.qrConfigOverride
+      uiOverrides?.qrConfigOverride,
+      footerTextData
     )
 
     const [app, metadataWallets] = await NightlyConnectSuiAdapter.initApp(appInitData)
@@ -185,7 +188,8 @@ export class NightlyConnectSuiAdapter {
       variablesOverride?: object
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
-    }
+    },
+    footerTextData?: FooterTextData[]
   ) => {
     const adapter = new NightlyConnectSuiAdapter(appInitData, eagerConnectForStandardWallets)
 
@@ -204,7 +208,8 @@ export class NightlyConnectSuiAdapter {
       anchorRef,
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
-      uiOverrides?.qrConfigOverride
+      uiOverrides?.qrConfigOverride,
+      footerTextData
     )
 
     adapter._loading = true
@@ -230,7 +235,8 @@ export class NightlyConnectSuiAdapter {
       variablesOverride?: object
       stylesOverride?: string
       qrConfigOverride?: Partial<XMLOptions>
-    }
+    },
+    footerTextData?: FooterTextData[]
   ) => {
     const adapter = new NightlyConnectSuiAdapter(appInitData, eagerConnectForStandardWallets, true)
 
@@ -250,7 +256,8 @@ export class NightlyConnectSuiAdapter {
       anchorRef,
       uiOverrides?.variablesOverride,
       uiOverrides?.stylesOverride,
-      uiOverrides?.qrConfigOverride
+      uiOverrides?.qrConfigOverride,
+      footerTextData
     )
 
     return adapter


### PR DESCRIPTION
### Objectives

1. Implement design from image
2. Change modal opening/closing animations
3. Expand modal API for optional parameters

### Part 1
<table>
<tr><th colspan="2">Design</th></tr>
<tr><td colspan="2"><img src="https://github.com/alicenoknow/connect/assets/56412617/152dae56-ae0b-4927-8f9b-f3bb5839d836" /></td></tr>
<tr colspan="2"><th>Implementation</th></tr>
<tr><th>Large</th><th>Medium</th></tr>
<tr><td><img src="https://github.com/alicenoknow/connect/assets/56412617/f7c2b81b-3d22-4b79-9d80-dce3c72fdfbf" /></td><td><img src="https://github.com/alicenoknow/connect/assets/56412617/e52c09cb-0ddf-4f30-875a-06deb26f1291"/></td></tr>
<tr><th>Small</th><th>Mobile</th></tr>
<tr><td><img src="https://github.com/alicenoknow/connect/assets/56412617/ed5579f2-b180-4b66-a267-c4a667f81810"/></td><td><img src="https://github.com/alicenoknow/connect/assets/56412617/a5fbd5b9-cee7-4766-9ee4-3d257001f6e6" /></td></tr>
</table>


### Part 2

Reference animation: [link here](https://test.common.fi/)

<table>
<tr><th>Web</th><th>Mobile</th></tr>
<tr><td>

https://github.com/alicenoknow/connect/assets/56412617/76973ed6-a0d5-4877-b745-6d781d30e2bb

</td><td>

https://github.com/alicenoknow/connect/assets/56412617/829f6fe3-fad8-4afc-be07-57de9e076949

</td></tr>
</table>

### Part 3

I've introduced optional parameter `additionalModalConfig ` of type `AdditionalModalConfig  | undefined` with following interface:
```ts
type FooterText = string;

interface FooterLink {
  url: string;
  name: string;
}

export type FooterTextData = FooterText | FooterLink;

export interface AdditionalModalConfig {
  footerTextData: ReadonlyArray<FooterTextData> | undefined
}
```

Here's example which produces footer visible on previous screens:

```js
additionalModalConfig: {
  footerTextData: [
      "By connecting, you agree to Common's ",
      { url: "", name: "Terms of Service" },
      " and its ",
      { url: "", name: "Privacy Policy" },
      "."
   ]
}

```